### PR TITLE
style: fix import order & formatting per pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: v0.12.10
     hooks:
       - id: ruff
+        args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+from loaders import DataLoadError, read_csv_safe
+
+
+def test_read_csv_safe_missing(tmp_path: Path):
+    # point to a file that does not exist
+    missing = tmp_path / "does_not_exist.csv"
+    with pytest.raises(DataLoadError) as exc:
+        read_csv_safe(missing)
+    # Helpful message for users
+    assert "Missing input file" in str(exc.value)
+
+
+def test_read_csv_safe_bad_csv(tmp_path: Path):
+    bad = tmp_path / "bad.csv"
+    bad.write_text(",,,,,\n,,")  # nonsense
+    with pytest.raises(DataLoadError):
+        read_csv_safe(bad)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,2 @@
+def test_project_imports():
+    import app  # noqa: F401


### PR DESCRIPTION
## 📌 Description
Add basic loader error-handling tests (`tests/test_loaders.py`) and fix import order/formatting per pre-commit hooks.  
Ensures CSV reading functions raise `DataLoadError` for missing/empty/corrupt files, making failures clearer.

Relates to #4 (error messaging), but does not close it.

---

## 🧩 Type of Change
- [x] 🧪 Tests (adding or improving test coverage)
- [x] 🔄 Refactor (style/formatting fixes)

---

## ✅ Checklist
- [x] Code style passes pre-commit (black, ruff, deptry)
- [x] Added tests for `read_csv_safe` and loader error handling
- [x] Verified tests pass locally (`make test`)
- [x] CI expected checks pass (pytest, pre-commit)